### PR TITLE
Renamed base clients

### DIFF
--- a/src/main/java/com/github/dannil/scbjavaclient/client/Client.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/Client.java
@@ -30,13 +30,13 @@ import com.github.dannil.scbjavaclient.utility.requester.RequestMethod;
 import com.github.dannil.scbjavaclient.utility.requester.RequesterFactory;
 
 /**
- * <p>Abstract class which specifies how clients should operate.</p>
+ * <p>Class which specifies how clients should operate.</p>
  * 
  * @author Daniel Nilsson
  */
-public abstract class AbstractClient {
+public class Client {
 
-	private static final Logger LOGGER = LogManager.getLogger(AbstractClient.class);
+	private static final Logger LOGGER = LogManager.getLogger(Client.class);
 
 	protected Locale locale;
 
@@ -45,7 +45,7 @@ public abstract class AbstractClient {
 	/**
 	 * <p>Default constructor.</p>
 	 */
-	protected AbstractClient() {
+	protected Client() {
 		this.locale = Locale.getDefault();
 		this.localization = new Localization(this.locale);
 	}
@@ -56,7 +56,7 @@ public abstract class AbstractClient {
 	 * @param locale
 	 *            the <code>Locale</code> for this client
 	 */
-	protected AbstractClient(Locale locale) {
+	protected Client(Locale locale) {
 		this();
 		this.locale = locale;
 		this.localization.setLocale(this.locale);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/ContainerClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/ContainerClient.java
@@ -19,22 +19,22 @@ import java.util.Collection;
 import java.util.Locale;
 
 /**
- * <p>Abstract class which specifies how methods by container clients (a client that has
+ * <p>Class which specifies how methods by container clients (a client that has
  * sub-clients) should operate.</p>
  * 
  * @author Daniel Nilsson
  */
-public abstract class AbstractContainerClient extends AbstractClient {
+public class ContainerClient extends Client {
 
-	protected Collection<AbstractClient> clients;
+	protected Collection<Client> clients;
 
 	/**
 	 * <p>Default constructor.</p>
 	 */
-	protected AbstractContainerClient() {
+	protected ContainerClient() {
 		super();
 
-		this.clients = new ArrayList<AbstractClient>();
+		this.clients = new ArrayList<Client>();
 	}
 
 	/**
@@ -43,10 +43,10 @@ public abstract class AbstractContainerClient extends AbstractClient {
 	 * @param locale
 	 *            the <code>Locale</code> for this client
 	 */
-	protected AbstractContainerClient(Locale locale) {
+	protected ContainerClient(Locale locale) {
 		this();
 
-		super.setLocale(locale);
+		this.setLocale(locale);
 	}
 
 	/**
@@ -56,8 +56,8 @@ public abstract class AbstractContainerClient extends AbstractClient {
 	public void setLocale(Locale locale) {
 		super.setLocale(locale);
 
-		for (AbstractClient client : this.clients) {
-			client.setLocale(super.locale);
+		for (Client client : this.clients) {
+			client.setLocale(this.locale);
 		}
 	}
 

--- a/src/main/java/com/github/dannil/scbjavaclient/client/ContainerClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/ContainerClient.java
@@ -53,7 +53,7 @@ public class ContainerClient extends Client {
 	 * <p>Set the <code>Locale</code> for all sub-clients.</p>
 	 */
 	@Override
-	public void setLocale(Locale locale) {
+	public final void setLocale(Locale locale) {
 		super.setLocale(locale);
 
 		for (Client client : this.clients) {

--- a/src/main/java/com/github/dannil/scbjavaclient/client/SCBClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/SCBClient.java
@@ -34,7 +34,7 @@ import com.github.dannil.scbjavaclient.utility.requester.RequesterFactory;
  * 
  * @author Daniel Nilsson
  */
-public class SCBClient extends AbstractContainerClient {
+public class SCBClient extends ContainerClient {
 
 	private PopulationClient populationClient;
 
@@ -47,10 +47,10 @@ public class SCBClient extends AbstractContainerClient {
 		super();
 
 		this.populationClient = new PopulationClient();
-		super.clients.add(this.populationClient);
+		this.clients.add(this.populationClient);
 
 		this.environmentClient = new EnvironmentClient();
-		super.clients.add(this.environmentClient);
+		this.clients.add(this.environmentClient);
 	}
 
 	/**
@@ -62,7 +62,7 @@ public class SCBClient extends AbstractContainerClient {
 	public SCBClient(Locale locale) {
 		this();
 
-		super.setLocale(locale);
+		this.setLocale(locale);
 	}
 
 	/**

--- a/src/main/java/com/github/dannil/scbjavaclient/client/environment/EnvironmentClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/environment/EnvironmentClient.java
@@ -16,7 +16,7 @@ package com.github.dannil.scbjavaclient.client.environment;
 
 import java.util.Locale;
 
-import com.github.dannil.scbjavaclient.client.AbstractContainerClient;
+import com.github.dannil.scbjavaclient.client.ContainerClient;
 import com.github.dannil.scbjavaclient.client.environment.landandwaterarea.EnvironmentLandAndWaterAreaClient;
 
 /**
@@ -24,7 +24,7 @@ import com.github.dannil.scbjavaclient.client.environment.landandwaterarea.Envir
  * 
  * @author Daniel Nilsson
  */
-public class EnvironmentClient extends AbstractContainerClient {
+public class EnvironmentClient extends ContainerClient {
 
 	private EnvironmentLandAndWaterAreaClient environmentLandAndWaterAreaClient;
 
@@ -35,7 +35,7 @@ public class EnvironmentClient extends AbstractContainerClient {
 		super();
 
 		this.environmentLandAndWaterAreaClient = new EnvironmentLandAndWaterAreaClient();
-		super.clients.add(this.environmentLandAndWaterAreaClient);
+		this.clients.add(this.environmentLandAndWaterAreaClient);
 	}
 
 	/**
@@ -47,7 +47,7 @@ public class EnvironmentClient extends AbstractContainerClient {
 	public EnvironmentClient(Locale locale) {
 		this();
 
-		super.setLocale(locale);
+		this.setLocale(locale);
 	}
 
 	/**

--- a/src/main/java/com/github/dannil/scbjavaclient/client/environment/landandwaterarea/EnvironmentLandAndWaterAreaClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/environment/landandwaterarea/EnvironmentLandAndWaterAreaClient.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import com.github.dannil.scbjavaclient.client.AbstractClient;
+import com.github.dannil.scbjavaclient.client.Client;
 import com.github.dannil.scbjavaclient.format.json.JsonCustomResponseFormat;
 import com.github.dannil.scbjavaclient.model.environment.landandwaterarea.Area;
 import com.github.dannil.scbjavaclient.utility.QueryBuilder;
@@ -31,7 +31,7 @@ import com.github.dannil.scbjavaclient.utility.QueryBuilder;
  * 
  * @author Daniel Nilsson
  */
-public class EnvironmentLandAndWaterAreaClient extends AbstractClient {
+public class EnvironmentLandAndWaterAreaClient extends Client {
 
 	/**
 	 * <p>Default constructor.</p>

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/PopulationClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/PopulationClient.java
@@ -16,7 +16,7 @@ package com.github.dannil.scbjavaclient.client.population;
 
 import java.util.Locale;
 
-import com.github.dannil.scbjavaclient.client.AbstractContainerClient;
+import com.github.dannil.scbjavaclient.client.ContainerClient;
 import com.github.dannil.scbjavaclient.client.population.amount.PopulationAmountClient;
 import com.github.dannil.scbjavaclient.client.population.averageage.PopulationAverageAgeClient;
 import com.github.dannil.scbjavaclient.client.population.demography.PopulationDemographyClient;
@@ -30,7 +30,7 @@ import com.github.dannil.scbjavaclient.client.population.partnership.PopulationP
  * 
  * @author Daniel Nilsson
  */
-public class PopulationClient extends AbstractContainerClient {
+public class PopulationClient extends ContainerClient {
 
 	private PopulationAmountClient populationAmountClient;
 
@@ -53,25 +53,25 @@ public class PopulationClient extends AbstractContainerClient {
 		super();
 
 		this.populationAmountClient = new PopulationAmountClient();
-		super.clients.add(this.populationAmountClient);
+		this.clients.add(this.populationAmountClient);
 
 		this.populationAverageAgeClient = new PopulationAverageAgeClient();
-		super.clients.add(this.populationAverageAgeClient);
+		this.clients.add(this.populationAverageAgeClient);
 
 		this.populationDemographyClient = new PopulationDemographyClient();
-		super.clients.add(this.populationDemographyClient);
+		this.clients.add(this.populationDemographyClient);
 
 		this.populationDensityClient = new PopulationDensityClient();
-		super.clients.add(this.populationDensityClient);
+		this.clients.add(this.populationDensityClient);
 
 		this.populationLiveBirthsClient = new PopulationLiveBirthsClient();
-		super.clients.add(populationLiveBirthsClient);
+		this.clients.add(populationLiveBirthsClient);
 
 		this.populationNameStatisticsClient = new PopulationNameStatisticsClient();
-		super.clients.add(this.populationNameStatisticsClient);
+		this.clients.add(this.populationNameStatisticsClient);
 
 		this.populationPartnershipClient = new PopulationPartnershipClient();
-		super.clients.add(this.populationPartnershipClient);
+		this.clients.add(this.populationPartnershipClient);
 	}
 
 	/**
@@ -83,7 +83,7 @@ public class PopulationClient extends AbstractContainerClient {
 	public PopulationClient(Locale locale) {
 		this();
 
-		super.setLocale(locale);
+		this.setLocale(locale);
 	}
 
 	/**

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/amount/PopulationAmountClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/amount/PopulationAmountClient.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import com.github.dannil.scbjavaclient.client.AbstractClient;
+import com.github.dannil.scbjavaclient.client.Client;
 import com.github.dannil.scbjavaclient.format.json.JsonCustomResponseFormat;
 import com.github.dannil.scbjavaclient.model.population.amount.Population;
 import com.github.dannil.scbjavaclient.utility.QueryBuilder;
@@ -31,7 +31,7 @@ import com.github.dannil.scbjavaclient.utility.QueryBuilder;
  * 
  * @author Daniel Nilsson
  */
-public class PopulationAmountClient extends AbstractClient {
+public class PopulationAmountClient extends Client {
 
 	/**
 	 * <p>Default constructor.</p>

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/averageage/PopulationAverageAgeClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/averageage/PopulationAverageAgeClient.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import com.github.dannil.scbjavaclient.client.AbstractClient;
+import com.github.dannil.scbjavaclient.client.Client;
 import com.github.dannil.scbjavaclient.format.json.JsonCustomResponseFormat;
 import com.github.dannil.scbjavaclient.model.population.averageage.AverageAge;
 import com.github.dannil.scbjavaclient.utility.QueryBuilder;
@@ -31,7 +31,7 @@ import com.github.dannil.scbjavaclient.utility.QueryBuilder;
  * 
  * @author Daniel Nilsson
  */
-public class PopulationAverageAgeClient extends AbstractClient {
+public class PopulationAverageAgeClient extends Client {
 
 	/**
 	 * <p>Default constructor.</p>

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/demography/PopulationDemographyClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/demography/PopulationDemographyClient.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import com.github.dannil.scbjavaclient.client.AbstractClient;
+import com.github.dannil.scbjavaclient.client.Client;
 import com.github.dannil.scbjavaclient.format.json.JsonCustomResponseFormat;
 import com.github.dannil.scbjavaclient.model.population.demography.FertilityRate;
 import com.github.dannil.scbjavaclient.model.population.demography.MeanAgeFirstChild;
@@ -32,7 +32,7 @@ import com.github.dannil.scbjavaclient.utility.QueryBuilder;
  * 
  * @author Daniel Nilsson
  */
-public class PopulationDemographyClient extends AbstractClient {
+public class PopulationDemographyClient extends Client {
 
 	/**
 	 * <p>Default constructor.</p>

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/density/PopulationDensityClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/density/PopulationDensityClient.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import com.github.dannil.scbjavaclient.client.AbstractClient;
+import com.github.dannil.scbjavaclient.client.Client;
 import com.github.dannil.scbjavaclient.format.json.JsonCustomResponseFormat;
 import com.github.dannil.scbjavaclient.model.population.density.Density;
 import com.github.dannil.scbjavaclient.utility.QueryBuilder;
@@ -31,7 +31,7 @@ import com.github.dannil.scbjavaclient.utility.QueryBuilder;
  * 
  * @author Daniel Nilsson
  */
-public class PopulationDensityClient extends AbstractClient {
+public class PopulationDensityClient extends Client {
 
 	/**
 	 * <p>Default constructor.</p>

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/livebirths/PopulationLiveBirthsClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/livebirths/PopulationLiveBirthsClient.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import com.github.dannil.scbjavaclient.client.AbstractClient;
+import com.github.dannil.scbjavaclient.client.Client;
 import com.github.dannil.scbjavaclient.format.json.JsonCustomResponseFormat;
 import com.github.dannil.scbjavaclient.model.population.livebirths.LiveBirth;
 import com.github.dannil.scbjavaclient.utility.QueryBuilder;
@@ -31,7 +31,7 @@ import com.github.dannil.scbjavaclient.utility.QueryBuilder;
  * 
  * @author Daniel Nilsson
  */
-public class PopulationLiveBirthsClient extends AbstractClient {
+public class PopulationLiveBirthsClient extends Client {
 
 	/**
 	 * <p>Default constructor.</p>

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/name/PopulationNameStatisticsClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/name/PopulationNameStatisticsClient.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import com.github.dannil.scbjavaclient.client.AbstractClient;
+import com.github.dannil.scbjavaclient.client.Client;
 import com.github.dannil.scbjavaclient.format.json.JsonCustomResponseFormat;
 import com.github.dannil.scbjavaclient.model.population.name.NumberOfChildrenBornWithFirstName;
 import com.github.dannil.scbjavaclient.utility.QueryBuilder;
@@ -31,7 +31,7 @@ import com.github.dannil.scbjavaclient.utility.QueryBuilder;
  * 
  * @author Daniel Nilsson
  */
-public class PopulationNameStatisticsClient extends AbstractClient {
+public class PopulationNameStatisticsClient extends Client {
 
 	/**
 	 * <p>Default constructor.</p>

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/partnership/PopulationPartnershipClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/partnership/PopulationPartnershipClient.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import com.github.dannil.scbjavaclient.client.AbstractClient;
+import com.github.dannil.scbjavaclient.client.Client;
 import com.github.dannil.scbjavaclient.format.json.JsonCustomResponseFormat;
 import com.github.dannil.scbjavaclient.model.population.partnership.Partnership;
 import com.github.dannil.scbjavaclient.model.population.partnership.PartnershipChange;
@@ -32,7 +32,7 @@ import com.github.dannil.scbjavaclient.utility.QueryBuilder;
  * 
  * @author Daniel Nilsson
  */
-public class PopulationPartnershipClient extends AbstractClient {
+public class PopulationPartnershipClient extends Client {
 
 	/**
 	 * <p>Default constructor.</p>

--- a/src/test/java/com/github/dannil/scbjavaclient/client/ClientIT.java
+++ b/src/test/java/com/github/dannil/scbjavaclient/client/ClientIT.java
@@ -42,9 +42,9 @@ import com.github.dannil.scbjavaclient.exception.SCBClientUrlNotFoundException;
 import com.github.dannil.scbjavaclient.utility.QueryBuilder;
 
 @RunWith(JUnit4.class)
-public class AbstractClientIT {
+public class ClientIT {
 
-	private class DummyClient extends AbstractClient {
+	private class DummyClient extends Client {
 
 		protected DummyClient() {
 			super();

--- a/src/test/java/com/github/dannil/scbjavaclient/client/ClientTest.java
+++ b/src/test/java/com/github/dannil/scbjavaclient/client/ClientTest.java
@@ -9,9 +9,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class AbstractClientTest {
+public class ClientTest {
 
-	private static class DummyContainerClient extends AbstractContainerClient {
+	private static class DummyContainerClient extends ContainerClient {
 
 		public DummyContainerClient(Locale locale) {
 			super(locale);
@@ -22,7 +22,7 @@ public class AbstractClientTest {
 	@Test
 	public void createWithLocaleConstructor() {
 		Locale locale = new Locale("sv", "SE");
-		AbstractContainerClient client = new DummyContainerClient(locale);
+		ContainerClient client = new DummyContainerClient(locale);
 
 		assertEquals(locale, client.getLocale());
 	}


### PR DESCRIPTION
Other:

Removed unnecessary super calls, which could break the class Client and
ContainerClient if they were subclassed in a specific way.

Slated for release 0.2.0 as this breaks API compatibility.