### PR TITLE
Clients accept empty lists as input

### DIFF
--- a/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
@@ -95,7 +95,7 @@ public final class QueryBuilder {
         Map<String, Collection<?>> filteredMap = new HashMap<>();
 
         for (Entry<String, Collection<?>> entry : inputMap.entrySet()) {
-            if (entry.getKey() != null && (entry.getValue() != null && entry.getValue().size() != 0)) {
+            if (entry.getKey() != null && (entry.getValue() != null && !entry.getValue().isEmpty())) {
                 filteredMap.put(entry.getKey(), filterValue(entry.getValue(), null));
             }
         }

--- a/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
@@ -64,13 +64,13 @@ public final class QueryBuilder {
      * <p>Constructs a query which matches the format the SCB API expects. This method
      * performs two distinct steps:</p>
      *
-     * <h1>1. Filter out the null keys</h1>
+     * <h1>1. Filter out the null keys and values</h1>
      *
-     * <p>If a key (such as region or year) is defined and all of this key's values are
-     * defined as null it means that all data for this key should be fetched (such as
-     * fetching the data for all available years). By not sending this key at all to the
-     * SCB API it recognizes that it should respond with all data corresponding to this
-     * key.</p>
+     * <p>If a key (such as region or year) is defined and it's value is either defined as
+     * null or as an empty list it means that all data for this key should be fetched
+     * (such as fetching the data for all available years). By not sending this key at all
+     * to the SCB API it recognizes that it should respond with all data corresponding to
+     * this key.</p>
      *
      * <h1>2. Construct the query</h1>
      *

--- a/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
@@ -95,8 +95,11 @@ public final class QueryBuilder {
         Map<String, Collection<?>> filteredMap = new HashMap<>();
 
         for (Entry<String, Collection<?>> entry : inputMap.entrySet()) {
-            if (entry.getKey() != null && entry.getValue() != null && !entry.getValue().isEmpty()) {
-                filteredMap.put(entry.getKey(), filterValue(entry.getValue(), null));
+            if (entry.getKey() != null && entry.getValue() != null) {
+                Collection<?> filtered = filterValue(entry.getValue(), null);
+                if (!filtered.isEmpty()) {
+                    filteredMap.put(entry.getKey(), filtered);
+                }
             }
         }
 

--- a/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
@@ -95,7 +95,7 @@ public final class QueryBuilder {
         Map<String, Collection<?>> filteredMap = new HashMap<>();
 
         for (Entry<String, Collection<?>> entry : inputMap.entrySet()) {
-            if (entry.getKey() != null && entry.getValue() != null) {
+            if (entry.getKey() != null && (entry.getValue() != null && entry.getValue().size() != 0)) {
                 filteredMap.put(entry.getKey(), filterValue(entry.getValue(), null));
             }
         }

--- a/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
@@ -66,8 +66,8 @@ public final class QueryBuilder {
      *
      * <h1>1. Filter out the null keys and values</h1>
      *
-     * <p>If a key (such as region or year) is defined and it's value is either defined as
-     * null or as an empty list it means that all data for this key should be fetched
+     * <p>If a key (such as region or year) is defined and its value is either defined as
+     * null or as an empty list, it means that all data for this key should be fetched
      * (such as fetching the data for all available years). By not sending this key at all
      * to the SCB API it recognizes that it should respond with all data corresponding to
      * this key.</p>

--- a/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/utility/QueryBuilder.java
@@ -95,7 +95,7 @@ public final class QueryBuilder {
         Map<String, Collection<?>> filteredMap = new HashMap<>();
 
         for (Entry<String, Collection<?>> entry : inputMap.entrySet()) {
-            if (entry.getKey() != null && (entry.getValue() != null && !entry.getValue().isEmpty())) {
+            if (entry.getKey() != null && entry.getValue() != null && !entry.getValue().isEmpty()) {
                 filteredMap.put(entry.getKey(), filterValue(entry.getValue(), null));
             }
         }

--- a/src/test/java/com/github/dannil/scbjavaclient/client/AbstractClientIT.java
+++ b/src/test/java/com/github/dannil/scbjavaclient/client/AbstractClientIT.java
@@ -27,6 +27,7 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -102,6 +103,23 @@ public class AbstractClientIT {
         assertTrue(response.contains("kön"));
         assertTrue(response.contains("boendeform"));
         assertTrue(response.contains("år"));
+    }
+
+    @Test
+    public void postWithEmptyList() {
+        DummyClient client = new DummyClient(new Locale("sv", "SE"));
+
+        String table = "HE/HE0103/HE0103B/BefolkningAlder";
+
+        Map<String, Collection<?>> inputMap = new HashMap<String, Collection<?>>();
+        inputMap.put("Alder", Collections.EMPTY_LIST);
+
+        String response = client.post(table, QueryBuilder.build(inputMap));
+
+        assertTrue(response.contains("år"));
+        assertFalse(response.contains("ålder"));
+        assertFalse(response.contains("kön"));
+        assertFalse(response.contains("boendeform"));
     }
 
     @Test

--- a/src/test/java/com/github/dannil/scbjavaclient/client/environment/landandwaterarea/EnvironmentLandAndWaterAreaClientIT.java
+++ b/src/test/java/com/github/dannil/scbjavaclient/client/environment/landandwaterarea/EnvironmentLandAndWaterAreaClientIT.java
@@ -17,6 +17,7 @@ package com.github.dannil.scbjavaclient.client.environment.landandwaterarea;
 import static org.junit.Assert.assertNotEquals;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.github.dannil.scbjavaclient.client.SCBClient;
@@ -49,6 +50,11 @@ public class EnvironmentLandAndWaterAreaClientIT extends RemoteIntegrationTestSu
         List<Integer> years = Arrays.asList(2012);
 
         assertNotEquals(0, this.environmentLandAndWaterAreaClient.getArea(regions, types, years).size());
+    }
+
+    @Test
+    public void getAreaWithParametersEmptyLists() {
+        assertNotEquals(0, this.environmentLandAndWaterAreaClient.getArea(Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<Integer>emptyList()));
     }
 
 }

--- a/src/test/java/com/github/dannil/scbjavaclient/client/environment/landandwaterarea/EnvironmentLandAndWaterAreaClientIT.java
+++ b/src/test/java/com/github/dannil/scbjavaclient/client/environment/landandwaterarea/EnvironmentLandAndWaterAreaClientIT.java
@@ -44,17 +44,17 @@ public class EnvironmentLandAndWaterAreaClientIT extends RemoteIntegrationTestSu
     }
 
     @Test
+    public void getAreaWithParametersEmptyLists() {
+        assertNotEquals(0, this.environmentLandAndWaterAreaClient.getArea(Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<Integer>emptyList()));
+    }
+
+    @Test
     public void getAreaWithParameters() {
         List<String> regions = Arrays.asList("1263");
         List<String> types = Arrays.asList("01", "02", "03", "04");
         List<Integer> years = Arrays.asList(2012);
 
         assertNotEquals(0, this.environmentLandAndWaterAreaClient.getArea(regions, types, years).size());
-    }
-
-    @Test
-    public void getAreaWithParametersEmptyLists() {
-        assertNotEquals(0, this.environmentLandAndWaterAreaClient.getArea(Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<Integer>emptyList()));
     }
 
 }

--- a/src/test/java/com/github/dannil/scbjavaclient/utility/QueryBuilderTest.java
+++ b/src/test/java/com/github/dannil/scbjavaclient/utility/QueryBuilderTest.java
@@ -16,6 +16,7 @@ package com.github.dannil.scbjavaclient.utility;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -41,6 +42,23 @@ public class QueryBuilderTest {
         cons[0].setAccessible(false);
 
         assertFalse(cons[0].isAccessible());
+    }
+
+    @Test
+    public void filterValue() {
+        Map<String, Collection<?>> inputMap = new HashMap<String, Collection<?>>();
+        inputMap.put("ContentsCode", Arrays.asList("HE0103D2"));
+        inputMap.put("Alder", Arrays.asList("tot", null));
+        inputMap.put("Kon", Arrays.asList("4"));
+        inputMap.put("Boendeform", Arrays.asList(null, null));
+        inputMap.put("Tid", Arrays.asList("2012"));
+
+        String query = QueryBuilder.build(inputMap);
+
+        assertFalse(query.contains("Boendeform"));
+        assertTrue(query.contains("Alder"));
+        assertTrue(query.contains("Kon"));
+        assertTrue(query.contains("Tid"));
     }
 
     @Test

--- a/src/test/java/com/github/dannil/scbjavaclient/utility/QueryBuilderTest.java
+++ b/src/test/java/com/github/dannil/scbjavaclient/utility/QueryBuilderTest.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -61,6 +62,16 @@ public class QueryBuilderTest {
         String query = QueryBuilder.build(inputMap);
 
         assertEquals("{\"query\": [{\"code\": \"Tid\", \"selection\": {\"filter\": \"item\", \"values\": [\"2012\"]}}],\"response\": {\"format\": \"json\"}}", query);
+    }
+
+    @Test
+    public void filterValueRemoveEmptyList() {
+        Map<String, Collection<?>> inputMap = new HashMap<String, Collection<?>>();
+        inputMap.put("Tid", Collections.EMPTY_LIST);
+
+        String query = QueryBuilder.build(inputMap);
+
+        assertEquals("{\"query\": [],\"response\": {\"format\": \"json\"}}", query);
     }
 
 }


### PR DESCRIPTION
The previous build-method was limited in the way that it only accepted null-values as a valid input if the user wanted to retrieve all information for a specific input. Now it is possibly to also specify an empty list (in addition to the previous way of null) as input, which is equivalent.

The unit test for this is located in QueryBuilderTest and the integration test is located in AbstractClientIT.