### PR TITLE
URL handling reworked throughout client hierarchy

### DIFF
--- a/src/main/java/com/github/dannil/scbjavaclient/client/AbstractClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/AbstractClient.java
@@ -113,15 +113,13 @@ public abstract class AbstractClient {
     }
 
     /**
-     * <p>Performs a GET request to the specified table.</p>
+     * <p>Performs a GET request to the specified URL.</p>
      *
-     * @param table
-     *            the table which will be sent a GET request
+     * @param url
+     *            the URL which will be sent a GET request
      * @return a string representation of the API's response
      */
-    protected String get(String table) {
-        String url = getRootUrl() + table;
-
+    protected String get(String url) {
         AbstractRequester get = new GETRequester();
         try {
             return get.getBody(url);
@@ -132,17 +130,15 @@ public abstract class AbstractClient {
     }
 
     /**
-     * <p>Performs a POST request to the specified table.</p>
+     * <p>Performs a POST request to the specified URL.</p>
      *
-     * @param table
-     *            the table which will be sent a POST request
+     * @param url
+     *            the URL which will be sent a POST request
      * @param query
      *            the query which the API will process
      * @return a string representation of the API's response
      */
-    protected String post(String table, String query) {
-        String url = getRootUrl() + table;
-
+    protected String post(String url, String query) {
         POSTRequester post = new POSTRequester();
         post.setQuery(query);
         try {
@@ -162,7 +158,8 @@ public abstract class AbstractClient {
      * @return a list of the available regions for the given table
      */
     public List<String> getRegions(String table) {
-        String json = get(table);
+        String url = getRootUrl() + table;
+        String json = get(url);
         String code = "Region";
 
         JsonAPITableFormat format = new JsonAPITableFormat(json);
@@ -177,7 +174,8 @@ public abstract class AbstractClient {
      * @return a list of the available years for the given table
      */
     public List<String> getYears(String table) {
-        String json = get(table);
+        String url = getRootUrl() + table;
+        String json = get(url);
         String code = "Tid";
 
         JsonAPITableFormat format = new JsonAPITableFormat(json);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/SCBClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/SCBClient.java
@@ -96,7 +96,8 @@ public class SCBClient extends AbstractContainerClient {
      *      JsonAPITableFormat#getInputs()
      */
     public Map<String, Collection<String>> getInputs(String table) {
-        String json = get(table);
+        String url = getRootUrl() + table;
+        String json = get(url);
 
         return new JsonAPITableFormat(json).getInputs();
     }
@@ -108,7 +109,8 @@ public class SCBClient extends AbstractContainerClient {
      * @return the config
      */
     public Map<String, String> getConfig() {
-        String json = get("?config");
+        String url = getRootUrl() + "?config";
+        String json = get(url);
 
         JsonAPIConfigTableFormat format = new JsonAPIConfigTableFormat(json);
 
@@ -150,7 +152,8 @@ public class SCBClient extends AbstractContainerClient {
      *      JsonAPITableFormat#getValues(String)
      */
     public String getRawData(String table) {
-        String json = get(table);
+        String url = getRootUrl() + table;
+        String json = get(url);
 
         Map<String, Collection<?>> inputs = new HashMap<>();
         inputs.put("ContentsCode", new JsonAPITableFormat(json).getValues("ContentsCode"));
@@ -169,7 +172,7 @@ public class SCBClient extends AbstractContainerClient {
      * @return a response from the API formatted as JSON
      */
     public String getRawData(String table, Map<String, Collection<?>> query) {
-        return post(table, QueryBuilder.build(query));
+        return post(getRootUrl() + table, QueryBuilder.build(query));
     }
 
     /**

--- a/src/main/java/com/github/dannil/scbjavaclient/client/environment/landandwaterarea/EnvironmentLandAndWaterAreaClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/environment/landandwaterarea/EnvironmentLandAndWaterAreaClient.java
@@ -83,7 +83,7 @@ public class EnvironmentLandAndWaterAreaClient extends AbstractClient {
         mappings.put("ArealTyp", types);
         mappings.put("Tid", years);
 
-        String response = post("MI/MI0802/Areal2012", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "Areal2012", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(Area.class);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/amount/PopulationAmountClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/amount/PopulationAmountClient.java
@@ -90,7 +90,7 @@ public class PopulationAmountClient extends AbstractClient {
         mappings.put("Kon", genders);
         mappings.put("Tid", years);
 
-        String response = post("BE/BE0101/BE0101A/BefolkningNy", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "BefolkningNy", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(Population.class);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/averageage/PopulationAverageAgeClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/averageage/PopulationAverageAgeClient.java
@@ -84,7 +84,7 @@ public class PopulationAverageAgeClient extends AbstractClient {
         mappings.put("Kon", genders);
         mappings.put("Tid", years);
 
-        String response = post("BE/BE0101/BE0101B/BefolkningMedelAlder", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "BefolkningMedelAlder", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(AverageAge.class);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/demography/PopulationDemographyClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/demography/PopulationDemographyClient.java
@@ -86,7 +86,7 @@ public class PopulationDemographyClient extends AbstractClient {
         mappings.put("Kon", genders);
         mappings.put("Tid", years);
 
-        String response = post("BE/BE0701/FruktsamhetSumNy", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "FruktsamhetSumNy", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(FertilityRate.class);
@@ -127,7 +127,7 @@ public class PopulationDemographyClient extends AbstractClient {
         mappings.put("Kon", genders);
         mappings.put("Tid", years);
 
-        String response = post("BE/BE0701/MedelAlderNY", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "MedelAlderNY", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(MeanAgeFirstChild.class);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/density/PopulationDensityClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/density/PopulationDensityClient.java
@@ -83,7 +83,7 @@ public class PopulationDensityClient extends AbstractClient {
         mappings.put("Kon", sexes);
         mappings.put("Tid", years);
 
-        String response = post("BE/BE0101/BE0101C/BefArealTathetKon", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "BefArealTathetKon", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(Density.class);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/livebirths/PopulationLiveBirthsClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/livebirths/PopulationLiveBirthsClient.java
@@ -87,7 +87,7 @@ public class PopulationLiveBirthsClient extends AbstractClient {
         mappings.put("Kon", genders);
         mappings.put("Tid", years);
 
-        String response = post("BE/BE0101/BE0101H/FoddaK", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "FoddaK", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(LiveBirth.class);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/name/PopulationNameStatisticsClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/name/PopulationNameStatisticsClient.java
@@ -82,7 +82,7 @@ public class PopulationNameStatisticsClient extends AbstractClient {
         mappings.put("Tilltalsnamn", firstnames);
         mappings.put("Tid", years);
 
-        String response = post("BE/BE0001/BE0001T04Ar", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "BE0001T04Ar", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(NumberOfChildrenBornWithFirstName.class);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/partnership/PopulationPartnershipClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/partnership/PopulationPartnershipClient.java
@@ -132,7 +132,7 @@ public class PopulationPartnershipClient extends AbstractClient {
         mappings.put("Kon", sexes);
         mappings.put("Tid", years);
 
-        String response = post("BE/BE0101/BE0101O/PartnerskapAndring", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "PartnerskapAndring", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(PartnershipChange.class);

--- a/src/main/java/com/github/dannil/scbjavaclient/client/population/partnership/PopulationPartnershipClient.java
+++ b/src/main/java/com/github/dannil/scbjavaclient/client/population/partnership/PopulationPartnershipClient.java
@@ -88,7 +88,7 @@ public class PopulationPartnershipClient extends AbstractClient {
         mappings.put("Kon", sexes);
         mappings.put("Tid", years);
 
-        String response = post("BE/BE0101/BE0101O/Partnerskap", QueryBuilder.build(mappings));
+        String response = post(getUrl() + "Partnerskap", QueryBuilder.build(mappings));
 
         JsonCustomResponseFormat format = new JsonCustomResponseFormat(response);
         return format.toListOf(Partnership.class);

--- a/src/test/java/com/github/dannil/scbjavaclient/client/AbstractClientIT.java
+++ b/src/test/java/com/github/dannil/scbjavaclient/client/AbstractClientIT.java
@@ -66,12 +66,12 @@ public class AbstractClientIT {
     public void toFallbackUrlGet() {
         DummyClient client = new DummyClient(new Locale("en", "US"));
 
-        String table = "HE/HE0103/HE0103B/BefolkningAlder";
+        String url = client.getRootUrl() + "HE/HE0103/HE0103B/BefolkningAlder";
 
         // This request is performed by a dummy Client which is set to English
         // (as specified in the setup method). This means that if we receive a response
         // with Swedish text, we've used the fallback url.
-        String response = client.get(client.getRootUrl() + table);
+        String response = client.get(url);
 
         assertTrue(response.contains("ålder"));
         assertTrue(response.contains("kön"));
@@ -84,7 +84,7 @@ public class AbstractClientIT {
     public void toFallbackUrlPost() {
         DummyClient client = new DummyClient(new Locale("en", "US"));
 
-        String table = "HE/HE0103/HE0103B/BefolkningAlder";
+        String url = client.getRootUrl() + "HE/HE0103/HE0103B/BefolkningAlder";
 
         Map<String, Collection<?>> map = new HashMap<String, Collection<?>>();
         map.put("ContentsCode", Arrays.asList("HE0103D2"));
@@ -96,7 +96,7 @@ public class AbstractClientIT {
         // This request is performed by a dummy client which is set to English
         // (as specified above when creating the client). This means that if we receive a
         // response with Swedish text, we've used the fallback url.
-        String response = client.post(client.getRootUrl() + table, QueryBuilder.build(map));
+        String response = client.post(url, QueryBuilder.build(map));
 
         assertTrue(response.contains("ålder"));
         assertTrue(response.contains("kön"));
@@ -108,12 +108,12 @@ public class AbstractClientIT {
     public void postWithEmptyList() {
         DummyClient client = new DummyClient(new Locale("sv", "SE"));
 
-        String table = "HE/HE0103/HE0103B/BefolkningAlder";
+        String url = client.getRootUrl() + "HE/HE0103/HE0103B/BefolkningAlder";
 
         Map<String, Collection<?>> inputMap = new HashMap<String, Collection<?>>();
         inputMap.put("Alder", Collections.EMPTY_LIST);
 
-        String response = client.post(client.getRootUrl() + table, QueryBuilder.build(inputMap));
+        String response = client.post(url, QueryBuilder.build(inputMap));
 
         assertTrue(response.contains("år"));
         assertFalse(response.contains("ålder"));
@@ -123,9 +123,9 @@ public class AbstractClientIT {
 
     @Test(expected = SCBClientUrlNotFoundException.class)
     public void urlNotFoundException() {
-        DummyClient client = new DummyClient();
+        SCBClient client = new SCBClient();
 
-        String response = client.get(client.getRootUrl() + "ABC/ABC/ABC");
+        String response = client.getRawData("ABC/ABC/ABC");
 
         assertNull(response);
     }

--- a/src/test/java/com/github/dannil/scbjavaclient/client/AbstractClientIT.java
+++ b/src/test/java/com/github/dannil/scbjavaclient/client/AbstractClientIT.java
@@ -67,12 +67,12 @@ public class AbstractClientIT {
     public void toFallbackUrlGet() {
         DummyClient client = new DummyClient(new Locale("en", "US"));
 
-        String url = "HE/HE0103/HE0103B/BefolkningAlder";
+        String table = "HE/HE0103/HE0103B/BefolkningAlder";
 
         // This request is performed by a dummy Client which is set to English
         // (as specified in the setup method). This means that if we receive a response
         // with Swedish text, we've used the fallback url.
-        String response = client.get(url);
+        String response = client.get(client.getRootUrl() + table);
 
         assertTrue(response.contains("ålder"));
         assertTrue(response.contains("kön"));
@@ -85,7 +85,7 @@ public class AbstractClientIT {
     public void toFallbackUrlPost() {
         DummyClient client = new DummyClient(new Locale("en", "US"));
 
-        String url = "HE/HE0103/HE0103B/BefolkningAlder";
+        String table = "HE/HE0103/HE0103B/BefolkningAlder";
 
         Map<String, Collection<?>> map = new HashMap<String, Collection<?>>();
         map.put("ContentsCode", Arrays.asList("HE0103D2"));
@@ -97,7 +97,7 @@ public class AbstractClientIT {
         // This request is performed by a dummy client which is set to English
         // (as specified above when creating the client). This means that if we receive a
         // response with Swedish text, we've used the fallback url.
-        String response = client.post(url, QueryBuilder.build(map));
+        String response = client.post(client.getRootUrl() + table, QueryBuilder.build(map));
 
         assertTrue(response.contains("ålder"));
         assertTrue(response.contains("kön"));
@@ -114,7 +114,7 @@ public class AbstractClientIT {
         Map<String, Collection<?>> inputMap = new HashMap<String, Collection<?>>();
         inputMap.put("Alder", Collections.EMPTY_LIST);
 
-        String response = client.post(table, QueryBuilder.build(inputMap));
+        String response = client.post(client.getRootUrl() + table, QueryBuilder.build(inputMap));
 
         assertTrue(response.contains("år"));
         assertFalse(response.contains("ålder"));
@@ -162,7 +162,7 @@ public class AbstractClientIT {
     public void urlNotFoundException() {
         DummyClient client = new DummyClient();
 
-        String response = client.get("ABC/ABC/ABC");
+        String response = client.get(client.getRootUrl() + "ABC/ABC/ABC");
 
         assertNull(response);
     }


### PR DESCRIPTION
Most importantly: get() and post() now accepts a full URL as input. This enables client to use their getUrl() as input to their POST call to the API. This also makes it easier for a possible transition towards #12 