### PR TITLE
Use Java 11 as lowest version on CI

### DIFF
--- a/.github/workflows/java-ci-all-tests.yml
+++ b/.github/workflows/java-ci-all-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         container: ['ubuntu:18.04']
-        jdk: [openjdk8]
+        jdk: [openjdk11]
         maven: [3.3.9]
       fail-fast: false
     runs-on: ubuntu-18.04

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         container: ['ubuntu:18.04']
-        jdk: [openjdk8, openjdk9, openjdk10, openjdk11, openjdk12, openjdk13]
+        jdk: [openjdk11, openjdk12, openjdk13]
         maven: [3.3.9]
       fail-fast: false
     runs-on: ubuntu-18.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: java
 os: linux
 dist: xenial
 jdk:
-  - openjdk8
-  - openjdk9
-  - openjdk10
   - openjdk11
   - openjdk12
   - openjdk13
@@ -37,7 +34,7 @@ script:
 - mvn install -B -V -DtestsDayLimit=7
 # SonarQube needs to be run with at least Java 8; also make sure we are on the correct branch
 after_success:
-- if [[ $TRAVIS_JDK_VERSION == openjdk8 && $TRAVIS_BRANCH == test/run-all-tests ]]; then
+- if [[ $TRAVIS_JDK_VERSION == openjdk11 && $TRAVIS_BRANCH == test/run-all-tests ]]; then
     mvn sonar:sonar -Dsonar.organization=dannil-github -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONARQUBE_TOKEN;
     rm -rf apache-maven-${MAVEN_VERSION}*;
     sh push_build_results.sh;


### PR DESCRIPTION
Blocked until version 2.6.0 is released.