### PR TITLE
Moved Java 14 to stable version

### DIFF
--- a/.github/workflows/ci-all-tests.yml
+++ b/.github/workflows/ci-all-tests.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 12, 13]
+        java: [11, 12, 13, 14]
       fail-fast: false
     name: Java ${{ matrix.java }}
     runs-on: ubuntu-16.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 12, 13, 14-ea, 15-ea]
+        java: [11, 12, 13, 14, 15-ea]
       fail-fast: false
     name: Java ${{ matrix.java }}
     runs-on: ubuntu-16.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
   - MAVEN_VERSION=3.3.9
 matrix:
   allow_failures:
-  - jdk: openjdk14
   - jdk: openjdk15
 before_install:
 - wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.zip


### PR DESCRIPTION
CI services now uses the stable Java 14 version and doesn't accept failure as a successful run.