### PR TITLE
Add Java 25 and drop Java 11

### DIFF
--- a/.github/workflows/ci-all-tests.yml
+++ b/.github/workflows/ci-all-tests.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [17, 21, 25]
       fail-fast: false
     name: Java ${{ matrix.java }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [17, 21, 25]
       fail-fast: false
     name: Java ${{ matrix.java }}
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <project.java.source>11</project.java.source>
-    <project.java.target>11</project.java.target>
+    <project.java.source>17</project.java.source>
+    <project.java.target>17</project.java.target>
 
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
   </properties>


### PR DESCRIPTION
Since Java 25 is in LTS now, add it to supported versions. Also drop support for Java 11.