### PR TITLE
Add grouped Dependabot updates for certain dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,13 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  ignore:
-  - dependency-name: com.fasterxml.jackson.core:jackson-*
-    versions:
-    - ">= 0"
-  - dependency-name: org.junit*
-    versions:
-    - ">= 0"
-  - dependency-name: ch.qos.logback:logback-*
-    versions:
-    - ">= 0"
+  groups:
+    jackson:
+      patterns:
+        - "com.fasterxml.jackson.core:jackson-*"
+    junit:
+      patterns:
+        - "org.junit*"
+    logback:
+      patterns:
+        - "ch.qos.logback:logback-*"


### PR DESCRIPTION
Some of our dependencies needs to be updated together since they have dependencies on each other. Dependabot nowadays supports this, so let's add support for it.